### PR TITLE
Added the colourpicker library

### DIFF
--- a/server.R
+++ b/server.R
@@ -7,6 +7,7 @@
 
 library(shiny)
 library(shinyjs)
+library(colourpicker)
 library(ggplot2)
 library(DT)
 library(data.table)

--- a/ui.R
+++ b/ui.R
@@ -7,6 +7,7 @@
 
 library(shiny)
 library(shinyjs)
+library(colourpicker)
 library(ggplot2)
 library(DT)
 


### PR DESCRIPTION
Some functions from shinyjs have been moved to the colourpicker library.

This results in the following error message:

> Warning: Error in : colourInput() has been moved to the 'colourpicker' package.

This pull request adds the colourpicker library and makes the warning/error message disappear.
